### PR TITLE
chore: use latest version of python-semantic-release

### DIFF
--- a/project/.github/workflows/ci.yml
+++ b/project/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
       # - Create GitHub release
       # - Publish to PyPI
       - name: Python Semantic Release
-        uses: relekang/python-semantic-release@v7.27.1
+        uses: relekang/python-semantic-release@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           pypi_token: ${{ secrets.PYPI_TOKEN }}

--- a/project/.github/workflows/ci.yml
+++ b/project/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
       # - Create GitHub release
       # - Publish to PyPI
       - name: Python Semantic Release
-        uses: relekang/python-semantic-release@master
+        uses: relekang/python-semantic-release@v7.32.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           pypi_token: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
After running this template, I found that the curernt specified version of `python-semantic-release` does not work properly with `error: No module named 'packaging'`. Hence, I would like to propose to always use the latest version, following the documentation of `python-semantic-release`.