### PR TITLE
chore: fix link to PyPI

### DIFF
--- a/project/docs/source/installation.md.jinja
+++ b/project/docs/source/installation.md.jinja
@@ -1,6 +1,6 @@
 # Installation
 
-The package is published on [PyPI](https://pypi.org/project/deezer-python/) and can be installed with `pip` (or any equivalent):
+The package is published on [PyPI](https://pypi.org/project/{{ project_slug }}/) and can be installed with `pip` (or any equivalent):
 
 ```bash
 pip install {{ project_slug }}


### PR DESCRIPTION
Fix linked to a specific project in `project/docs/source/installation.md.jinja`