### PR TITLE
Fix CI badges and documentation index

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Python Package Template
 
 <a href="https://github.com/browniebroke/pypackage-template/actions?query=workflow%3ACI">
-  <img src="https://img.shields.io/github/workflow/status/browniebroke/pypackage-template/CI/main?label=Test&logo=github&style=flat-square" alt="CI Status" >
+  <img src="https://img.shields.io/github/actions/workflow/status/browniebroke/pypackage-template/ci.yml?branch=main&label=Test&logo=github&style=flat-square" alt="CI Status" >
 </a>
 
 Project template for a Python Package using Copier.

--- a/project/README.md.jinja
+++ b/project/README.md.jinja
@@ -2,7 +2,7 @@
 
 <p align="center">
   <a href="https://github.com/{{ github_username }}/{{ project_slug }}/actions?query=workflow%3ACI">
-    <img src="https://img.shields.io/github/workflow/status/{{ github_username }}/{{ project_slug }}/CI/main?label=CI&logo=github&style=flat-square" alt="CI Status" >
+    <img src="https://img.shields.io/github/actions/workflow/status/{{ github_username }}/{{ project_slug }}/ci.yml?branch=main&label=CI&logo=github&style=flat-square" alt="CI Status" >
   </a>
   {%- if documentation %}
   <a href="https://{{ project_slug }}.readthedocs.io">

--- a/project/docs/index.md.jinja
+++ b/project/docs/index.md.jinja
@@ -16,6 +16,6 @@ changelog
 contributing
 ```
 
-```{include} ../../README.md
+```{include} ../README.md
 
 ```


### PR DESCRIPTION
The CI shields were adjusted according to https://github.com/badges/shields/issues/8671

The README file was not correctly included into the documentation index.