### PR TITLE
ci: add Python 3.12 to the CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
-          # - "3.12-dev"
+          - "3.12-dev"
         os:
           - ubuntu-latest
           # - windows-latest

--- a/project/.github/workflows/ci.yml
+++ b/project/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
-          # - "3.12-dev"
+          - "3.12-dev"
         os:
           - ubuntu-latest
           - windows-latest


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos