### PR TITLE
ci: use latest Python 3 for simple workflow steps

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.x
       - name: Install labels
         run: pip install labels
       - name: Sync config with Github

--- a/project/.github/workflows/ci.yml
+++ b/project/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: 3.x
       - uses: pre-commit/action@v3.0.0
 
   # Make sure commit messages follow the conventional commits convention:

--- a/project/.github/workflows/labels.yml
+++ b/project/.github/workflows/labels.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.x
       - name: Install labels
         run: pip install labels
       - name: Sync config with Github


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos