### PR TITLE
fix: ignore commits with unknown category in PSR

### DIFF
--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -75,8 +75,9 @@ build_command = "pip install poetry && poetry build"
 
 [tool.semantic_release.changelog]
 exclude_commit_patterns = [
-    "chore*",
-    "ci*",
+    "chore.*",
+    "ci.*",
+    "Merge pull request .*",
 ]
 
 [tool.semantic_release.changelog.environment]

--- a/project/templates/CHANGELOG.md.j2
+++ b/project/templates/CHANGELOG.md.j2
@@ -4,7 +4,7 @@
 
 ## {{ version.as_tag() }} ({{ release.tagged_date.strftime("%Y-%m-%d") }})
 
-{%- for category, commits in release["elements"].items() %}
+{%- for category, commits in release["elements"].items() %}{% if category != "unknown" %}
 {# Category title: Breaking, Fix, Documentation #}
 ### {{ category | capitalize }}
 {# List actual changes in the category #}
@@ -12,6 +12,6 @@
 - {{ commit.descriptions[0] | capitalize }} ([`{{ commit.short_hash }}`]({{ commit.hexsha | commit_hash_url }}))
 {%- endfor %}{# for commit #}
 
-{%- endfor %}{# for category, commits #}
+{%- endif %}{% endfor %}{# for category, commits #}
 
 {%- endfor %}{# for version, release #}


### PR DESCRIPTION
### Description of change

Ignore commits with unknown categories in PSR changelog generation.

### Pull-Request Checklist

- [x] Code is up-to-date with the `main` branch
- [x] This pull request follows the [contributing guidelines](https://github.com/browniebroke/pypackage-template/blob/main/CONTRIBUTING.md).
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

Fix issue reported in https://github.com/python-semantic-release/python-semantic-release/issues/1019

cc @abe-101