### PR TITLE
fix: make it easier to generate migrations for a Django package

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,20 @@ Here is an overview of what it's doing:
 - Build the source and binary distribution (wheel).
 - Upload the sources to PyPI and attach them to the Github release, using trusted publisher.
 
-For more details, check out the [conventional commits website][conventional-commits] and [Python semantic release][python-semantic-release] Github action.
+For more details, check out the [conventional commits website][conventional-commits] and [Python semantic release][python-semantic-release] GitHub action.
+
+### Optional: Django package
+
+If your package is a reusable Django app, you should answer "yes" to the question "Is the project a Django package?". This will generate a bit more boilerplate for you to make it easier to develop and test:
+
+- At the root, you'll get a `manage.py` which is going to come handy if your package contain any models and you need to run migrations for it.
+- Testing will use tox as the Django-Python support matrix can be complicated.
+- Inside your package source, you'll get a `conf.py` to include your reusable app settings, for the users of your app to configure your app. This is following the pattern explained in [this blog post](https://overtag.dk/v2/blog/a-settings-pattern-for-reusable-django-apps/).
+- The tests will come in with settings and URLs files, along with an test app with basic models.
+
+#### Migrations
+
+You should be able to use the provided `manage.py` to create migrations for your reusable app. Create or change your models and run `poetry run python manage.py makemigrations`.
 
 ### Pre-commit
 

--- a/project/tests/{% if is_django_package %}settings.py{% endif %}.jinja
+++ b/project/tests/{% if is_django_package %}settings.py{% endif %}.jinja
@@ -13,11 +13,41 @@ DATABASES = {
 USE_TZ = True
 TIME_ZONE = "UTC"
 ROOT_URLCONF = "tests.urls"
+DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 INSTALLED_APPS = [
     "django.contrib.auth",
     "django.contrib.admin",
     "django.contrib.contenttypes",
+    "django.contrib.sessions",
+    "django.contrib.messages",
+    "django.contrib.staticfiles",
     "{{ package_name }}",
     "tests.testapp",
+]
+
+MIDDLEWARE = [
+    "django.middleware.security.SecurityMiddleware",
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.common.CommonMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
+    "django.middleware.clickjacking.XFrameOptionsMiddleware",
+]
+
+TEMPLATES = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [],
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [
+                "django.template.context_processors.debug",
+                "django.template.context_processors.request",
+                "django.contrib.auth.context_processors.auth",
+                "django.contrib.messages.context_processors.messages",
+            ],
+        },
+    },
 ]

--- a/project/{% if is_django_package %}manage.py{% endif %}.jinja
+++ b/project/{% if is_django_package %}manage.py{% endif %}.jinja
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+"""Django's command-line utility for administrative tasks."""
+import os
+import sys
+
+
+def main():
+    """Run administrative tasks."""
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "tests.settings")
+    try:
+        from django.core.management import execute_from_command_line
+    except ImportError as exc:
+        raise ImportError(
+            "Couldn't import Django. Are you sure it's installed and "
+            "available on your PYTHONPATH environment variable? Did you "
+            "forget to activate a virtual environment?"
+        ) from exc
+    execute_from_command_line(sys.argv)
+
+
+if __name__ == "__main__":
+    main()

--- a/project/{% if is_django_package %}manage.py{% endif %}.jinja
+++ b/project/{% if is_django_package %}manage.py{% endif %}.jinja
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 """Django's command-line utility for administrative tasks."""
+
 import os
 import sys
 

--- a/project/{% if is_django_package %}manage.py{% endif %}.jinja
+++ b/project/{% if is_django_package %}manage.py{% endif %}.jinja
@@ -4,7 +4,7 @@ import os
 import sys
 
 
-def main():
+def main() -> None:
     """Run administrative tasks."""
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "tests.settings")
     try:

--- a/tests/test_generate_project.py
+++ b/tests/test_generate_project.py
@@ -240,6 +240,9 @@ def test_django_package_yes(
     )
 
     assert tmp_path.exists()
+    assert (
+        dst_path / "src" / "django_snake_farm" / "migrations" / "__init__.py"
+    ).exists()
     _check_file_contents(
         dst_path / "pyproject.toml",
         expected_strs=[
@@ -249,6 +252,12 @@ def test_django_package_yes(
             'pytest-django = "^4.5"',
             "--ds=tests.settings",
             "django_find_project = false",
+        ],
+    )
+    _check_file_contents(
+        dst_path / "manage.py",
+        expected_strs=[
+            'os.environ.setdefault("DJANGO_SETTINGS_MODULE", "tests.settings")',
         ],
     )
     _check_file_contents(
@@ -273,6 +282,9 @@ def test_django_package_yes(
         expected_strs=[
             'SECRET_KEY = "NOTASECRET"  # noqa S105',
             '    "django_snake_farm",',
+            "MIDDLEWARE = [",
+            "TEMPLATES = [",
+            'DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"',
         ],
     )
     _check_file_contents(
@@ -350,6 +362,8 @@ def test_django_package_no(
     )
 
     assert tmp_path.exists()
+    assert not (dst_path / "src" / "snake_farm" / "migrations" / "__init__.py").exists()
+    assert not (dst_path / "manage.py").exists()
     assert not (dst_path / "src" / "snake_farm" / "conf.py").exists()
     assert not (dst_path / "src" / "snake_farm" / "apps.py").exists()
     assert not (dst_path / "tests" / "settings.py").exists()


### PR DESCRIPTION
### Description of change

Make it easier to generate migrations for reusable Django app (see https://github.com/browniebroke/pypackage-template/discussions/817)

### Pull-Request Checklist

- [x] Code is up-to-date with the `main` branch
- [x] This pull request follows the [contributing guidelines](https://github.com/browniebroke/pypackage-template/blob/main/CONTRIBUTING.md).
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `poetry run pytest` for further information.