### PR TITLE
fix: cleanup docs copier task does not work on windows

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -113,7 +113,7 @@ _tasks:
   # Remove licence file if no license
   - "{% if open_source_license == 'Not open source' %}rm LICENSE{% endif %}"
   # Cleanup docs
-  - "{% if not documentation %}python -c \"import os, shutil; shutil.rmtree('docs'); os.remove('.readthedocs.yml') \"{% endif %}"
+  - '{% if not documentation %}python -c "import os, shutil; shutil.rmtree(''docs''); os.remove(''.readthedocs.yml'') "{% endif %}'
   # Run 'uv sync' to generate lockfile
   - "{% if run_uv_sync %}uv sync{% endif %}"
   # Initial commit

--- a/copier.yml
+++ b/copier.yml
@@ -113,7 +113,7 @@ _tasks:
   # Remove licence file if no license
   - "{% if open_source_license == 'Not open source' %}rm LICENSE{% endif %}"
   # Cleanup docs
-  - "{% if not documentation %}rm -rf docs .readthedocs.yml{% endif %}"
+  - "{% if not documentation %}python -c \"import os, shutil; shutil.rmtree('docs'); os.remove('.readthedocs.yml') \"{% endif %}"
   # Run 'uv sync' to generate lockfile
   - "{% if run_uv_sync %}uv sync{% endif %}"
   # Initial commit


### PR DESCRIPTION
### Description of change

This change replaces the `rm -rf` command in the copier documentation cleanup task with a Python snippet (`shutil.rmtree` and `os.remove`). The previous implementation (`rm -rf`) failed in Windows PowerShell because the `-rf` options are not supported. The new implementation uses Python, which should work consistently on all platforms.
I also removed the `forced` option because I expect the `docs` directory and the `.readthedocs.yml` file to exist and deleting should work.

### Pull-Request Checklist

- [x] Code is up-to-date with the `main` branch
- [x] This pull request follows the [contributing guidelines](https://github.com/browniebroke/pypackage-template/blob/main/CONTRIBUTING.md).
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `uv run pytest` for further information.
