### PR TITLE
ci: fix coverage reporting with parallel runs for Django package

### DIFF
--- a/project/.github/workflows/ci.yml.jinja
+++ b/project/.github/workflows/ci.yml.jinja
@@ -57,6 +57,10 @@ jobs:
         shell: bash
       - run: tox -f py$(echo ${{ matrix.python-version }} | tr -d .)
         shell: bash
+      - run: |
+          uv run coverage combine
+          uv run coverage xml
+        shell: bash
 {% endraw %}
 {%- else %}{% raw %}
       - uses: actions/setup-python@v5

--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -53,10 +53,12 @@ scripts.{{ cli_name }} = "{{ package_name }}.cli:app"
 
 [dependency-groups]
 dev = [
+  "coverage",
   "pytest>=8,<9",
-  "pytest-cov>=6,<7",
 {%- if is_django_package  %}
   "pytest-django>=4.5,<5",
+{%- else  %}
+  "pytest-cov>=6,<7",
 {%- endif %}
 ]
 {%- if documentation %}
@@ -109,17 +111,28 @@ lint.isort.known-first-party = [ "{{ package_name }}", "tests" ]
 addopts = """\
     -v
     -Wdefault
+{%- if is_django_package  %}
+    --ds=tests.settings
+{%- else  %}
     --cov={{ package_name }}
     --cov-report=term
     --cov-report=xml
-{%- if is_django_package  %}
-    --ds=tests.settings
 {%- endif  %}
     """
 pythonpath = [ "src" ]
 
 [tool.coverage.run]
 branch = true
+{%- if is_django_package  %}
+parallel = true
+source = [ "{{ package_name }}" ]
+{%- endif  %}
+
+[tool.coverage.paths]
+source = [
+  "src",
+  ".tox/**/site-packages",
+]
 
 [tool.coverage.report]
 exclude_lines = [

--- a/project/{% if is_django_package %}tox.ini{% endif %}.jinja
+++ b/project/{% if is_django_package %}tox.ini{% endif %}.jinja
@@ -21,4 +21,5 @@ deps =
     django42: Django>=4.2,<5.0
 commands =
     python \
+      -m coverage run \
       -m pytest {posargs:tests}


### PR DESCRIPTION
### Description of change

The coverage report for Django package may be wrong in Codecov, because we don't have `parallel = true`, and we run multiple Django versions on the same CI worker, so only the latest version of Django that runs is reported. In case where the code has `if django.VERSION >= ... ` branches, some branches appear uncovered.

The generated project uses pytest-cov which does not work with this option:

> This plugin overrides the parallel option of coverage. Unless you also run coverage without pytest-cov it’s pointless to set those options in your .coveragerc.

Dropping this dependency in case of Django package.

### Pull-Request Checklist

- [x] Code is up-to-date with the `main` branch
- [x] This pull request follows the [contributing guidelines](https://github.com/browniebroke/pypackage-template/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".