### PR TITLE
chore: delete setup.py from generated project

### DIFF
--- a/project/setup.py.jinja
+++ b/project/setup.py.jinja
@@ -1,9 +1,0 @@
-#!/usr/bin/env python
-
-# This is a shim to allow GitHub to detect the package, build is done with uv
-# Taken from https://github.com/Textualize/rich
-
-import setuptools
-
-if __name__ == "__main__":
-    setuptools.setup(name="{{ project_slug }}")


### PR DESCRIPTION
### Description of change

I tried to remove it on a couple of projects and the "Used by" still oworks, so it seems that GitHub now reads the project metadata correctly from `pyproject.toml`, hence this is no longer needed.

I'm pretty sure someone asked about that a few months ago, but I can no longer find the discussion/issue/PR.

### Pull-Request Checklist

- [x] Code is up-to-date with the `main` branch
- [x] This pull request follows the [contributing guidelines](https://github.com/browniebroke/pypackage-template/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".
