### PR TITLE
feat: add support for Django 6.0

### DIFF
--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -25,6 +25,7 @@ classifiers = [
   "Framework :: Django :: 5.0",
   "Framework :: Django :: 5.1",
   "Framework :: Django :: 5.2",
+  "Framework :: Django :: 6.0",
   {%- endif  %}
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
@@ -72,6 +73,7 @@ docs = [
 ]
 {%- endif %}
 {%- if is_django_package %}
+django60 = [ "django>=6.0a1,<6.1; python_version>='3.12'" ]
 django52 = [ "django>=5.2a1,<6" ]
 django51 = [ "django>=5.1a1,<5.2" ]
 django50 = [ "django>=5.0a1,<5.1" ]
@@ -80,6 +82,7 @@ django42 = [ "django>=4.2a1,<5" ]
 [tool.uv]
 conflicts = [
   [
+    { group = "django60" },
     { group = "django52" },
     { group = "django51" },
     { group = "django50" },

--- a/project/{% if is_django_package %}tox.ini{% endif %}.jinja
+++ b/project/{% if is_django_package %}tox.ini{% endif %}.jinja
@@ -3,9 +3,9 @@ isolated_build = true
 requires =
     tox>=4.2
 env_list =
-    py314-django{52}
-    py313-django{52,51}
-    py312-django{52,51,50,42}
+    py314-django{60,52}
+    py313-django{60,52,51}
+    py312-django{60,52,51,50,42}
     py311-django{52,51,50,42}
     py310-django{52,51,50,42}
 
@@ -16,6 +16,7 @@ set_env =
 dependency_groups =
     dev
 deps =
+    django60: django60
     django52: django52
     django51: django51
     django50: django50

--- a/tests/test_generate_project.py
+++ b/tests/test_generate_project.py
@@ -244,10 +244,11 @@ def test_django_package_yes(
             '"Framework :: Django :: 5.0",',
             '"Framework :: Django :: 5.1",',
             '"Framework :: Django :: 5.2",',
+            '"Framework :: Django :: 6.0",',
             '"django>=4.2"',
             "pytest-django>=4.5,<5",
             "--ds=tests.settings",
-            'django52 = [ "django>=5.2a1,<6" ]',
+            "django60 = [ \"django>=6.0a1,<6.1; python_version>='3.12'\" ]",
             'django42 = [ "django>=4.2a1,<5" ]',
         ],
     )
@@ -324,6 +325,7 @@ def test_django_package_yes(
             "django50: django50",
             "django51: django51",
             "django52: django52",
+            "django60: django60",
         ],
     )
     _check_file_contents(


### PR DESCRIPTION
### Description of change

- Ensure tox uses uv.lock file to run tests
- Generate Django app with Django 6.0 support by default

### Pull-Request Checklist

- [ ] Code is up-to-date with the `main` branch
- [ ] This pull request follows the [contributing guidelines](https://github.com/browniebroke/pypackage-template/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".