### PR TITLE
feat: update pytest config for version 9

### DIFF
--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -132,20 +132,22 @@ lint.isort.known-first-party = [ "{{ package_name }}", "tests" ]
 [tool.pyproject-fmt]
 max_supported_python = "3.14"
 
-[tool.pytest.ini_options]
-addopts = """\
-    -v
-    -Wdefault
-    -p no:doctest
-{%- if is_django_package  %}
-    --ds=tests.settings
-{%- else  %}
-    --cov={{ package_name }}
-    --cov-report=term
-    --cov-report=xml
+[tool.pytest]
+minversion = "9.0"
+addopts = [
+  "-v",
+  "-Wonce",
+  "-p no:doctest",
+{%- if not is_django_package  %}
+  "--cov={{ package_name }}",
+  "--cov-report=term",
+  "--cov-report=xml"
 {%- endif  %}
-    """
+]
 pythonpath = [ "src" ]
+{%- if is_django_package  %}
+DJANGO_SETTINGS_MODULE = "tests.settings"
+{%- endif  %}
 
 [tool.coverage.run]
 branch = true

--- a/tests/test_generate_project.py
+++ b/tests/test_generate_project.py
@@ -263,7 +263,7 @@ def test_django_package_yes(
             '"Framework :: Django :: 6.0",',
             '"django>=4.2"',
             "pytest-django==",
-            "--ds=tests.settings",
+            'DJANGO_SETTINGS_MODULE = "tests.settings"',
             "django60 = [ \"django>=6.0a1,<6.1; python_version>='3.12'\" ]",
             'django42 = [ "django>=4.2a1,<5" ]',
         ],


### PR DESCRIPTION
### Description of change

The config for pytest can now be specified in the `[tool.pytest]` table instead of the old `[tool.pytest.ini_options]`, but the config need to be adjusted a bit.

### Pull-Request Checklist

- [x] Code is up-to-date with the `main` branch
- [x] This pull request follows the [contributing guidelines](https://github.com/browniebroke/pypackage-template/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `uv run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->
