### PR TITLE
fix: don't use my own Renovate config unless GitHub username is my own

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Project template for a Python Package using Copier.
 
 ## Features
 
-- Project for Python 3.9+.
+- Project for Python 3.10+.
 - Testing with Pytest using GitHub actions.
 - Packaging powered by [uv].
 - Optionally generates a CLI entry point powered by [Typer] and [Rich].

--- a/project/renovate.json.jinja
+++ b/project/renovate.json.jinja
@@ -1,4 +1,23 @@
 {
+{%- if github_username == "browniebroke" %}
   "extends": ["github>browniebroke/renovate-configs:python"]{% if is_django_package %},
   "ignoreDeps": ["django"]{% endif %}
+{%- else  %}
+  "extends": [
+    "config:best-practices",
+    ":pinOnlyDevDependencies",
+    ":automergeAll",
+    ":enablePreCommit"
+  ],
+{%- if is_django_package %}
+  "ignoreDeps": ["django"],
+{%- endif %}
+  "packageRules": [
+    {
+      "matchPackageNames": ["python"],
+      "rangeStrategy": "widen",
+      "separateMultipleMinor": true
+    }
+  ]
+{%- endif  %}
 }

--- a/tests/test_generate_project.py
+++ b/tests/test_generate_project.py
@@ -70,6 +70,36 @@ def test_defaults_values(
             'license = "MIT"',
         ],
     )
+    _check_file_contents(
+        dst_path / "renovate.json",
+        expected_strs=['"config:best-practices"'],
+        unexpect_strs=['"github>browniebroke/renovate-configs:python"'],
+    )
+
+
+def test_author_customisation(
+    tmp_path: Path,
+    base_answers: dict[str, str | bool],
+):
+    answers = {
+        **base_answers,
+        "github_username": "browniebroke",
+    }
+    dst_path = tmp_path / "snake-farm"
+    worker = copier.run_copy(
+        src_path=str(PROJECT_ROOT),
+        dst_path=dst_path,
+        data=answers,
+        defaults=True,
+        unsafe=True,
+    )
+    assert worker is not None
+    assert tmp_path.exists()
+    _check_file_contents(
+        dst_path / "renovate.json",
+        expected_strs=['"github>browniebroke/renovate-configs:python"'],
+        unexpect_strs=['"config:best-practices"'],
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Description of change

Update `renovate.json` to use my own config based on the GitHub username, using plain config otherwise.

Fix #939 

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following to merge this PR.

  Note that there is no problem if they are not checked when this PR is created.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `main` branch
- [x] This pull request follows the [contributing guidelines](https://github.com/browniebroke/pypackage-template/blob/main/CONTRIBUTING.md).
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If the lint job is failing, try `prek run -a` for further information.
> - If CI / test is failing, try `uv run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->
