### PR TITLE
feat: replace prettier by oxfmt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
           - run: "uv run python -m pytest"
             dir: ""
             name: "pytest"
-          - run: "git init && git add . && uvx prek run -a"
+          - run: "git init && git add . && uvx prek run -a --show-diff-on-failure --color=always"
             dir: ""
             name: "prek"
           - run: "uv run make html"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,11 +26,10 @@ repos:
     rev: 0.11.6
     hooks:
       - id: uv-lock
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.1.0
+  - repo: https://github.com/oxc-project/mirrors-oxfmt
+    rev: v0.45.0
     hooks:
-      - id: prettier
-        args: ["--tab-width", "2"]
+      - id: oxfmt
         exclude: LICENSE
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.10

--- a/project/.editorconfig
+++ b/project/.editorconfig
@@ -10,6 +10,9 @@ insert_final_newline = true
 charset = utf-8
 end_of_line = lf
 
+[*.json]
+indent_size = 2
+
 [*.bat]
 indent_style = tab
 end_of_line = crlf

--- a/project/.editorconfig
+++ b/project/.editorconfig
@@ -10,7 +10,7 @@ insert_final_newline = true
 charset = utf-8
 end_of_line = lf
 
-[*.{json,js,mjs}]
+[*.{json,js,mjs,toml}]
 indent_size = 2
 
 [*.bat]

--- a/project/.editorconfig
+++ b/project/.editorconfig
@@ -10,7 +10,7 @@ insert_final_newline = true
 charset = utf-8
 end_of_line = lf
 
-[*.json]
+[*.{json,js,mjs}]
 indent_size = 2
 
 [*.bat]

--- a/project/.pre-commit-config.yaml.jinja
+++ b/project/.pre-commit-config.yaml.jinja
@@ -35,11 +35,10 @@ repos:
     rev: 0.11.6
     hooks:
       - id: uv-lock
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.1.0
+  - repo: https://github.com/oxc-project/mirrors-oxfmt
+    rev: v0.45.0
     hooks:
-      - id: prettier
-        args: ["--tab-width", "2"]
+      - id: oxfmt
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.10
     hooks:


### PR DESCRIPTION
### Description of change

The prettier pre-commit hook mirror is archived. Migrate to oxfmt

Fix #908

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following to merge this PR.

  Note that there is no problem if they are not checked when this PR is created.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `main` branch
- [x] This pull request follows the [contributing guidelines](https://github.com/browniebroke/pypackage-template/blob/main/CONTRIBUTING.md).
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If the lint job is failing, try `prek run -a` for further information.
> - If CI / test is failing, try `uv run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->
