### PR TITLE
feat: drop Django < 5.2 support

### DIFF
--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -18,9 +18,6 @@ classifiers = [
   "Development Status :: 2 - Pre-Alpha",
   {%- if is_django_package %}
   "Framework :: Django",
-  "Framework :: Django :: 4.2",
-  "Framework :: Django :: 5.0",
-  "Framework :: Django :: 5.1",
   "Framework :: Django :: 5.2",
   "Framework :: Django :: 6.0",
   {%- endif  %}
@@ -38,7 +35,7 @@ classifiers = [
 {%- if is_django_package or has_cli  %}
 dependencies = [
   {%- if is_django_package  %}
-  "django>=4.2",
+  "django>=5.2",
   {%- endif %}
   {%- if has_cli  %}
   "rich>=10",
@@ -79,18 +76,12 @@ docs = [
 ]
 {%- endif %}
 {%- if is_django_package %}
-django42 = [ "django>=4.2a1,<5" ]
-django50 = [ "django>=5.0a1,<5.1" ]
-django51 = [ "django>=5.1a1,<5.2" ]
 django52 = [ "django>=5.2a1,<6" ]
 django60 = [ "django>=6.0a1,<6.1; python_version>='3.12'" ]
 
 [tool.uv]
 conflicts = [
   [
-    { group = "django42" },
-    { group = "django50" },
-    { group = "django51" },
     { group = "django52" },
     { group = "django60" },
   ],

--- a/project/{% if is_django_package %}tox.ini{% endif %}.jinja
+++ b/project/{% if is_django_package %}tox.ini{% endif %}.jinja
@@ -4,10 +4,10 @@ requires =
     tox>=4.2
 env_list =
     py314-django{60,52}
-    py313-django{60,52,51}
-    py312-django{60,52,51,50,42}
-    py311-django{52,51,50,42}
-    py310-django{52,51,50,42}
+    py313-django{60,52}
+    py312-django{60,52}
+    py311-django{52}
+    py310-django{52}
 
 [testenv]
 runner = uv-venv-lock-runner
@@ -18,9 +18,6 @@ dependency_groups =
 deps =
     django60: django60
     django52: django52
-    django51: django51
-    django50: django50
-    django42: django42
 commands =
     python \
       -m coverage run \

--- a/tests/test_generate_project.py
+++ b/tests/test_generate_project.py
@@ -296,16 +296,13 @@ def test_django_package_yes(
     _check_file_contents(
         dst_path / "pyproject.toml",
         expected_strs=[
-            '"Framework :: Django :: 4.2",',
-            '"Framework :: Django :: 5.0",',
-            '"Framework :: Django :: 5.1",',
             '"Framework :: Django :: 5.2",',
             '"Framework :: Django :: 6.0",',
-            '"django>=4.2"',
+            '"django>=5.2"',
             "pytest-django==",
             'DJANGO_SETTINGS_MODULE = "tests.settings"',
             "django60 = [ \"django>=6.0a1,<6.1; python_version>='3.12'\" ]",
-            'django42 = [ "django>=4.2a1,<5" ]',
+            'django52 = [ "django>=5.2a1,<6" ]',
             "[tool.mypy]",
         ],
         unexpect_strs=["[tool.ty]"],
@@ -402,9 +399,6 @@ def test_django_package_yes(
     _check_file_contents(
         dst_path / "tox.ini",
         expected_strs=[
-            "django42: django42",
-            "django50: django50",
-            "django51: django51",
             "django52: django52",
             "django60: django60",
         ],
@@ -448,11 +442,9 @@ def test_django_package_no(
         dst_path / "pyproject.toml",
         expected_strs=["[tool.ty]", 'src.exclude = [ "docs/" ]'],
         unexpect_strs=[
-            '"Framework :: Django :: 4.2",',
-            '"Framework :: Django :: 5.0",',
-            '"Framework :: Django :: 5.1",',
             '"Framework :: Django :: 5.2",',
-            '"django>=4.2"',
+            '"Framework :: Django :: 6.0",',
+            '"django>=5.2"',
             "pytest-django>=4.5,<5",
             "[tool.mypy]",
         ],


### PR DESCRIPTION
BREAKING CHANGE: drop support for Django < 5.2

Committed via https://github.com/asottile/all-repos