### PR TITLE
feat: remove the need for a long-lived GH token

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -10,8 +10,11 @@ on:
 jobs:
   labels:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
       - name: Sync config with Github
-        run: uvx labels -u ${{ github.repository_owner }} -t ${{ secrets.GH_PAT }} sync -f .github/labels.toml
+        run: uvx labels -u ${{ github.repository_owner }} -t ${{ secrets.GITHUB_TOKEN }} sync -f .github/labels.toml

--- a/README.md
+++ b/README.md
@@ -65,9 +65,8 @@ A `labels` workflow will also run and synchronise the GitHub labels based on the
 
 ### Secrets
 
-The workflows need [a few secrets][gh-secrets] to be setup in your GitHub repository:
+The workflows need [a secret][gh-secrets] to be setup in your GitHub repository:
 
-- `GH_PAT` a [personal access token (PAT) with the `repo` scope][create-pat] for opening pull requests and updating the repository topics. This is used by the `upgrader` and `labels` workflows.
 - `CODECOV_TOKEN` to upload coverage data to [codecov.io][codecov] in the Test workflow.
 
 If you have the GitHub CLI installed and chose to set up GitHub, they will be created with a dummy value (`changeme`).

--- a/copier.yml
+++ b/copier.yml
@@ -117,7 +117,6 @@ _tasks:
   # Setup GitHub
   - '{% if _copier_operation == "copy" and setup_github %}gh repo create {{ github_username }}/{{ project_slug }} -d "{{ project_short_description }}" --public --remote=origin --source=. --push{% endif %}'
   - "{% if _copier_operation == 'copy' and setup_github %}gh repo edit --delete-branch-on-merge --enable-projects=false --enable-wiki=false{% endif %}"
-  - '{% if _copier_operation == "copy" and setup_github %}gh secret set GH_PAT -b "changeme"{% endif %}'
   - '{% if _copier_operation == "copy" and setup_github %}gh secret set CODECOV_TOKEN -b "changeme"{% endif %}'
   # Add me as a contributor
   - "{% if _copier_operation == 'copy' and add_me_as_contributor %}npx --yes all-contributors-cli add {{ github_username }} code,ideas,doc{% endif %}"

--- a/project/.github/workflows/labels.yml
+++ b/project/.github/workflows/labels.yml
@@ -10,8 +10,11 @@ on:
 jobs:
   labels:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
       - name: Sync config with Github
-        run: uvx labels -u ${{ github.repository_owner }} -t ${{ secrets.GH_PAT }} sync -f .github/labels.toml
+        run: uvx labels -u ${{ github.repository_owner }} -t ${{ secrets.GITHUB_TOKEN }} sync -f .github/labels.toml


### PR DESCRIPTION
### Description of change

Remove the `GH_PAT` from the template and generated projects.

### Pull-Request Checklist

- [x] Code is up-to-date with the `main` branch
- [x] This pull request follows the [contributing guidelines](https://github.com/browniebroke/pypackage-template/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".
